### PR TITLE
Migrate to new ORM approach.

### DIFF
--- a/pin-service/api/models.py
+++ b/pin-service/api/models.py
@@ -1,10 +1,12 @@
-from sqlalchemy import Column, String, Integer
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
 from .database import Base
 from geoalchemy2 import Geometry
 
 
 class Pin(Base):
     __tablename__ = "pin"
-    id = Column(Integer, primary_key=True)
-    name = Column(String)
-    geom = Column(Geometry(geometry_type='POINT', srid=4326))
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(50))
+    geom: Mapped[Geometry] = mapped_column(
+        Geometry(geometry_type='POINT', srid=4326))


### PR DESCRIPTION
SQLAlchemy 2.0 uses this approach, so migrating to this approach will allow for an easier time reading and using the docs.